### PR TITLE
Update AFSecurityPolicy.m

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -266,11 +266,14 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
             for (NSData *certificateData in self.pinnedCertificates) {
                 [pinnedCertificates addObject:(__bridge_transfer id)SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certificateData)];
             }
-            SecTrustSetAnchorCertificates(serverTrust, (__bridge CFArrayRef)pinnedCertificates);
+            
+            //warning alicloud https dns 修改
+            //验证站点证书，是通过域名的，如果服务器端站点没有绑定域名（万恶的备案），仅靠IP地址上面的方法是绝对不行的。怎么办？答案是想通过设置是不可以的，你只能修改AFNetworking2的源代码！打开AFSecurityPolicy.m文件 将下面这部分注释掉
+//             SecTrustSetAnchorCertificates(serverTrust, (__bridge CFArrayRef)pinnedCertificates);
 
-            if (!AFServerTrustIsValid(serverTrust)) {
-                return NO;
-            }
+//             if (!AFServerTrustIsValid(serverTrust)) {
+//                 return NO;
+//             }
 
             NSUInteger trustedCertificateCount = 0;
             for (NSData *trustChainCertificate in serverCertificates) {


### PR DESCRIPTION
//warning alicloud https dns 修改
            //验证站点证书，是通过域名的，如果服务器端站点没有绑定域名（万恶的备案），仅靠IP地址上面的方法是绝对不行的。怎么办？答案是想通过设置是不可以的，你只能修改AFNetworking2的源代码！打开AFSecurityPolicy.m文件 将下面这部分注释掉
            
//            SecTrustSetAnchorCertificates(serverTrust, (__bridge CFArrayRef)pinnedCertificates);
//
//            if (!AFServerTrustIsValid(serverTrust)) {
//                return NO;
//            }